### PR TITLE
Fix Dockerfile copy stage references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ WORKDIR /app
 
 # Copy only necessary files
 COPY --from=builder /app/package.json ./
-COPY --from=build /app/node_modules ./node_modules
-COPY --from=build /app/dist ./dist
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
Correct the references in the Dockerfile to ensure the proper files are copied from the builder stage.