### PR TITLE
Specify namespace for kubectl rollout status in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,4 +76,4 @@ jobs:
             kubectl apply -f deployment/deployment.final.yaml
             kubectl apply -f deployment/service.yaml
             kubectl apply -f deployment/ingress.yaml
-            kubectl rollout status deployment/${{ env.IMAGE_NAME }}
+            kubectl rollout status deployment/${{ env.IMAGE_NAME }} -n wizeworks


### PR DESCRIPTION
Add the namespace parameter to the kubectl rollout status command in the deployment configuration.