### PR TITLE
Remove unnecessary service type declaration in service.yaml

### DIFF
--- a/deployment/service.yaml
+++ b/deployment/service.yaml
@@ -12,4 +12,3 @@ spec:
     - protocol: TCP
       port: 80
       targetPort: 8080
-  type: ClusterIP


### PR DESCRIPTION
Eliminate the redundant service type declaration to streamline the configuration.