### PR TITLE
Update namespace to development and version to 1.0.9

### DIFF
--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: wize-comment
-  namespace: wizeworks
+  namespace: development
   labels:
     app: wize-comment
 spec:

--- a/deployment/ingress.yaml
+++ b/deployment/ingress.yaml
@@ -2,11 +2,11 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: wize-comment-ingress
-  namespace: wizeworks
+  namespace: development
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-brandonkorous
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   ingressClassName: nginx
   tls:
@@ -17,7 +17,7 @@ spec:
     - host: api.wize.works
       http:
         paths:
-          - path: /comment/(.*)
+          - path: /comment(/|$)(.*)
             pathType: Prefix
             backend:
               service:

--- a/deployment/service.yaml
+++ b/deployment/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: wize-comment-service
-  namespace: wizeworks
+  namespace: development
   labels:
     app: wize-comment
 spec:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "wize-comment",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "wize-comment",
-            "version": "1.0.8",
+            "version": "1.0.9",
             "license": "ISC",
             "dependencies": {
                 "@clerk/fastify": "^2.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wize-comment",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "description": "Multi-tenant GraphQL API for handling comment threads",
     "main": "dist/server.js",
     "type": "commonjs",


### PR DESCRIPTION
Change the namespace from wizeworks to development in deployment files and update the version of the wize-comment package to 1.0.9.